### PR TITLE
Enable clean shutdown with Ctrl+C

### DIFF
--- a/featherweb/__init__.py
+++ b/featherweb/__init__.py
@@ -41,8 +41,7 @@ class FeatherWeb(object):
             try:
                 events = poller.poll(timeout*1000)
                 if not events and callback:
-                    if not callback(**kwargs):
-                        break
+                    running = callback(**kwargs):
                     continue
 
                 for fd, event in events:
@@ -83,12 +82,12 @@ class FeatherWeb(object):
 
                         handler(response)
 
-                    except Exception as e:
-                        client.sendall('HTTP/1.0 404 NA\r\n\r\n')
-
                     except KeyboardInterrupt:
                         print('Got Ctrl-C, shutting down...')
                         running = False
+
+                    except Exception as e:
+                        client.sendall('HTTP/1.0 404 NA\r\n\r\n')
 
                     finally:
                         client.close()

--- a/featherweb/__init__.py
+++ b/featherweb/__init__.py
@@ -41,7 +41,7 @@ class FeatherWeb(object):
             try:
                 events = poller.poll(timeout*1000)
                 if not events and callback:
-                    running = callback(**kwargs):
+                    running = callback(**kwargs)
                     continue
 
                 for fd, event in events:


### PR DESCRIPTION
Hi there!

Thanks for sharing your work with featherweb! 😄 

I started using it for a simple project with the ESP32, and noticed that after stopping the server with Ctrl+C it won't start it again - when I run it, bind() causes "OSError: [Errno 98] EADDRINUSE".

This small patch solves this and provides a more graceful termination.